### PR TITLE
Calculate site aa composition & substitutions on a per-comparison-group basis

### DIFF
--- a/drhip/methods/busted.py
+++ b/drhip/methods/busted.py
@@ -130,36 +130,26 @@ class BustedMethod(HyPhyMethod):
         # Parse the tree
         internal_branches = {}
         tree = tree_helpers.newick_parser(results['input']['trees']['0'], {}, internal_branches)
-        
+
         # Process each site
         for site_idx, site_subs in substitutions.items():
             # Convert to 1-based indexing to match FEL and other methods
             site_num = int(site_idx) + 1
             
-            # Initialize composition and substitution counters
+            # Initialize composition and substitution dictionaries
             composition = {}
             subs = {}
             
-            # Check if we have comparison groups available
-            has_comparison_groups = False
-            comparison_groups = []
-            if hasattr(self, '_comparison_groups') and self._comparison_groups:
-                if len(self._comparison_groups) > 0:
-                    has_comparison_groups = True
-                    comparison_groups = self._comparison_groups
-            
-            # Initialize composition and substitution dictionaries
-            for group in comparison_groups:
-                # Traverse the tree to collect composition and substitution data for each group
-                tree_helpers.traverse_tree(
-                    tree, 
-                    None, 
-                    site_subs, 
-                    internal_branches, 
-                    composition, 
-                    subs, 
-                    group  # Use each group as leaf label
-                )
+            # Traverse the tree to collect composition and substitution data for each group
+            tree_helpers.traverse_tree(
+                tree, 
+                None, 
+                site_subs, 
+                internal_branches, 
+                composition, 
+                subs, 
+                None  # no leaf labels
+            )
             
             # Process the composition data
             site_composition = []
@@ -180,10 +170,10 @@ class BustedMethod(HyPhyMethod):
                 'majority_residue': 'NA'
             }
             
-            # Calculate majority residue if we have comparison groups
-            if has_comparison_groups and comparison_groups[0] in composition and composition[comparison_groups[0]]:
+            # Calculate majority residue for test (internal) branches
+            if 'test' in composition and composition['test']:
                 sorted_residues = sorted(
-                    [[aa, count] for aa, count in composition[comparison_groups[0]].items()],
+                    [[aa, count] for aa, count in composition['test'].items()],
                     key=lambda d: -d[1]
                 )
                 if sorted_residues:

--- a/drhip/methods/cfel.py
+++ b/drhip/methods/cfel.py
@@ -343,10 +343,11 @@ class CfelMethod(HyPhyMethod):
                         tree,
                         None,
                         site_subs,
-                        track_tags,
+                        track_tags,  # track_tags SHOULD be the same as tested, but who knows
                         composition_all,
                         subs_all,
-                        None  # use natural tags from the tree for leaves
+                        None,  # do not overwrite leaf tags
+                        ignore_leaves=True
                     )
                 except Exception:
                     continue
@@ -364,6 +365,16 @@ class CfelMethod(HyPhyMethod):
                     comp_counts = composition_all.get(group, {})
                     comp_list = [f"{aa}:{count}" for aa, count in comp_counts.items()]
                     comparison_data[site_id][group]['composition'] = ','.join(comp_list) if comp_list else 'NA'
+
+                    # Majority residue for this group
+                    sorted_residues = sorted(
+                        [[aa, count] for aa, count in comp_counts.items()],
+                        key=lambda d: -d[1]
+                    )
+                    if sorted_residues:
+                        comparison_data[site_id][group]['majority_residue'] = sorted_residues[0][0]
+                    else:
+                        comparison_data[site_id][group]['majority_residue'] = 'NA'
 
                     # Substitutions for this group
                     sub_counts = subs_all.get(group, {})
@@ -393,6 +404,7 @@ class CfelMethod(HyPhyMethod):
             'cfel_beta',         # Per-group beta value for this site
             'composition',       # Per-group composition at this site
             'substitutions',     # Per-group substitutions at this site
+            'majority_residue'   # Per-group majority residue at this site
         ]
         
     @staticmethod

--- a/drhip/methods/cfel.py
+++ b/drhip/methods/cfel.py
@@ -363,24 +363,14 @@ class CfelMethod(HyPhyMethod):
 
                     # Composition for this group
                     comp_counts = composition_all.get(group, {})
-                    comp_list = [f"{aa}:{count}" for aa, count in comp_counts.items()]
-                    comparison_data[site_id][group]['composition'] = ','.join(comp_list) if comp_list else 'NA'
+                    comparison_data[site_id][group]['composition'] = su.format_composition(comp_counts)
 
                     # Majority residue for this group
-                    sorted_residues = sorted(
-                        [[aa, count] for aa, count in comp_counts.items()],
-                        key=lambda d: -d[1]
-                    )
-                    if sorted_residues:
-                        comparison_data[site_id][group]['majority_residue'] = sorted_residues[0][0]
-                    else:
-                        comparison_data[site_id][group]['majority_residue'] = 'NA'
+                    comparison_data[site_id][group]['majority_residue'] = su.get_majority_residue(comp_counts)
 
                     # Substitutions for this group
                     sub_counts = subs_all.get(group, {})
-                    # Ignore housekeeping keys if any
-                    subs_list = [f"{sub}:{count}" for sub, count in sub_counts.items() if sub and sub != 'transition']
-                    comparison_data[site_id][group]['substitutions'] = ','.join(subs_list) if subs_list else 'NA'
+                    comparison_data[site_id][group]['substitutions'] = su.format_substitutions(sub_counts)
         
         return comparison_data
         

--- a/tests/test_tree_helpers.py
+++ b/tests/test_tree_helpers.py
@@ -208,6 +208,7 @@ def test_traverse_tree_group_specific():
     
     # Create mock data
     labels = {
+        "root": "ATT",
         "node1": "ATG",
         "node2": "ATT",
         "node3": "ATT",
@@ -222,7 +223,7 @@ def test_traverse_tree_group_specific():
     }
     
     # Initialize tracking dictionaries
-    composition = {}  # fucker only counts leaves
+    composition = {}
     subs = {}
     
     # Traverse tree
@@ -236,7 +237,9 @@ def test_traverse_tree_group_specific():
     
     # Check substitution tracking - should have background tag with substitutions
     assert "background" in subs
+    assert "foreground" in subs
     assert "I:M" in subs["background"] or "M:I" in subs["background"]
+    assert "I:M" in subs["foreground"] or "M:I" in subs["foreground"]
 
 def test_traverse_tree_non_group_specific():
     """Test tree traversal function."""
@@ -283,7 +286,7 @@ def test_traverse_tree_non_group_specific():
     }
     
     # Initialize tracking dictionaries
-    composition = {}  # fucker only counts leaves
+    composition = {}
     subs = {}
     
     # Traverse tree

--- a/tests/test_tree_helpers.py
+++ b/tests/test_tree_helpers.py
@@ -209,7 +209,7 @@ def test_traverse_tree_group_specific():
     # Create mock data
     labels = {
         "node1": "ATG",
-        "node2": "ATG",
+        "node2": "ATT",
         "node3": "ATT",
         "node4": "ATT"
     }
@@ -226,15 +226,74 @@ def test_traverse_tree_group_specific():
     subs = {}
     
     # Traverse tree
-    th.traverse_tree(tree, None, labels, labeler, composition, subs, "foreground")
+    th.traverse_tree(tree, None, labels, labeler, composition, subs, ignore_leaves=True)
     
     # Check composition tracking
     assert "foreground" in composition
-    assert "background" in composition
     assert "reference" in composition
-    assert composition["foreground"] == {"M": 1}
-    assert composition["background"] == {"I": 1}
-    # assert composition["reference"] == {"M": 1}
+    assert composition["foreground"] == {"I": 1}  # foreground is parent of node2, which has the I residue
+    assert composition["reference"] == {"I": 1}
+    
+    # Check substitution tracking - should have background tag with substitutions
+    assert "background" in subs
+    assert "I:M" in subs["background"] or "M:I" in subs["background"]
+
+def test_traverse_tree_non_group_specific():
+    """Test tree traversal function."""
+    # Create a simple tree
+    tree = {
+        "name": "root",
+        "children": [
+            {
+                "name": "node1",
+                "tag": "foreground",
+                "children": [
+                    {
+                        "name": "node2",
+                        "tag": "background"
+                    }
+                ]
+            },
+            {
+                "name": "node3",
+                "tag": "reference",
+                "children": [
+                    {
+                        "name": "node4",
+                        "tag": "background"
+                    }
+                ]
+            }
+        ]
+    }
+    
+    # Create mock data
+    labels = {
+        "node1": "ATG",
+        "node2": "ATT",
+        "node3": "ATT",
+        "node4": "ATT"
+    }
+    
+    labeler = {
+        "node1": "foreground",
+        "node2": "background",
+        "node3": "reference",
+        "node4": "background"
+    }
+    
+    # Initialize tracking dictionaries
+    composition = {}  # fucker only counts leaves
+    subs = {}
+    
+    # Traverse tree
+    th.traverse_tree(tree, None, labels, labeler, composition, subs, ignore_leaves=False)
+    
+    # Check composition tracking
+    assert "foreground" not in composition
+    assert "background" in composition
+    assert "reference" not in composition
+    assert composition["background"] == {"I": 2}
     
     # Check substitution tracking - should have background tag with substitutions
     assert "background" in subs

--- a/tests/test_tree_helpers.py
+++ b/tests/test_tree_helpers.py
@@ -177,7 +177,7 @@ def test_traverse_tree():
     assert "background" in subs
     assert "I:M" in subs["background"] or "M:I" in subs["background"]
 
-def test_traverse_tree():
+def test_traverse_tree_group_specific():
     """Test tree traversal function."""
     # Create a simple tree
     tree = {

--- a/tests/test_tree_helpers.py
+++ b/tests/test_tree_helpers.py
@@ -170,6 +170,71 @@ def test_traverse_tree():
     # Check composition tracking
     assert "foreground" in composition
     assert "background" in composition
+    assert composition["foreground"] == {"M": 1}
+    assert composition["background"] == {"I": 1}
+    
+    # Check substitution tracking - should have background tag with substitutions
+    assert "background" in subs
+    assert "I:M" in subs["background"] or "M:I" in subs["background"]
+
+def test_traverse_tree():
+    """Test tree traversal function."""
+    # Create a simple tree
+    tree = {
+        "name": "root",
+        "children": [
+            {
+                "name": "node1",
+                "tag": "foreground",
+                "children": [
+                    {
+                        "name": "node2",
+                        "tag": "background"
+                    }
+                ]
+            },
+            {
+                "name": "node3",
+                "tag": "reference",
+                "children": [
+                    {
+                        "name": "node4",
+                        "tag": "background"
+                    }
+                ]
+            }
+        ]
+    }
+    
+    # Create mock data
+    labels = {
+        "node1": "ATG",
+        "node2": "ATG",
+        "node3": "ATT",
+        "node4": "ATT"
+    }
+    
+    labeler = {
+        "node1": "foreground",
+        "node2": "background",
+        "node3": "reference",
+        "node4": "background"
+    }
+    
+    # Initialize tracking dictionaries
+    composition = {}  # fucker only counts leaves
+    subs = {}
+    
+    # Traverse tree
+    th.traverse_tree(tree, None, labels, labeler, composition, subs, "foreground")
+    
+    # Check composition tracking
+    assert "foreground" in composition
+    assert "background" in composition
+    assert "reference" in composition
+    assert composition["foreground"] == {"M": 1}
+    assert composition["background"] == {"I": 1}
+    # assert composition["reference"] == {"M": 1}
     
     # Check substitution tracking - should have background tag with substitutions
     assert "background" in subs

--- a/tests/test_tree_helpers.py
+++ b/tests/test_tree_helpers.py
@@ -232,6 +232,7 @@ def test_traverse_tree_group_specific():
     # Check composition tracking
     assert "foreground" in composition
     assert "reference" in composition
+    assert "background" not in composition
     assert composition["foreground"] == {"I": 1}  # foreground is parent of node2, which has the I residue
     assert composition["reference"] == {"I": 1}
     


### PR DESCRIPTION
## Summary
- Enriches CFEL comparison output with per-group compositions, majority residues, and formatted substitution summaries derived from HyPhy’s updated Contrast-FEL results format. (`drhip/methods/cfel.py:311`)
- Extends the tree traversal helper with an `ignore_leaves` option so leaf branches can inherit internal branch tags when counting amino acid composition. Adds tests for the new option. (`drhip/utils/tree_helpers.py:213`, `tests/test_tree_helpers.py:176`)
- Streamlines BUSTED site post-processing by removing the `process_comparison_site_data()` method. BUSTED no longer handles any comparison data. `drhip/methods/busted.py:147`.

## Tests
- New tests in `pytest tests/test_tree_helpers.py` are all passing. 
- I did a quick integration test on some of my own H5N1 data and confirmed that the amino acid composition at each site across all groups sums to the same number of taxa reported in the CFEL results file.