### PR TITLE
Export all pvals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Mac stuff:
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ The toolkit produces combined files that aggregate data across all genes:
   - Number of sites (sites)
 
 - **combined_sites.csv**: Site-specific analysis including:
-  - Beta values per comparison group
+  - FEL raw p-values (`fel_pval`) and Benjamini-Hochberg adjusted q-values (`fel_qval`)
+  - MEME raw p-values (`meme_pval`) and Benjamini-Hochberg adjusted q-values (`meme_qval`)
+  - FEL alpha and beta values
   - Inferred substitutions at each site
   - Site amino acid composition
 
@@ -115,8 +117,9 @@ The combined files automatically include the superset of all fields found across
 
 The toolkit uses consistent markers to represent different types of data:
 
-- **Significant Results**: Actual values (p-values, property names, etc.)
-- **Non-significant Results**: "-" marker for most fields
+- **P-values and q-values**: FEL, MEME, and Contrast-FEL site outputs report numeric values whenever they are available, regardless of significance
+- **Significant Results**: Actual values (property names, selection labels, etc.)
+- **Non-significant Results**: "-" marker for fields that are categorical markers rather than raw statistics
 - **Missing or Malformed Data**: "NA" marker
 
 If data for a particular method is missing for a gene, or if the data is malformed or cannot be processed, the toolkit will output "NA" in the corresponding fields. This allows for easy identification of missing data versus non-significant results.

--- a/drhip/config.py
+++ b/drhip/config.py
@@ -38,6 +38,8 @@ SITES_FIELDNAMES = [
     "meme_marker",
     "fel_selection",
     "fel_pval",
+    "fel_alpha",
+    "fel_beta",
 ]
 
 COMPARISON_GROUPS_SUMMARY_FIELDNAMES = [

--- a/drhip/config.py
+++ b/drhip/config.py
@@ -37,6 +37,7 @@ SITES_FIELDNAMES = [
     "prime_qval",
     "meme_marker",
     "fel_selection",
+    "fel_pval",
 ]
 
 COMPARISON_GROUPS_SUMMARY_FIELDNAMES = [

--- a/drhip/config.py
+++ b/drhip/config.py
@@ -35,9 +35,11 @@ SITES_FIELDNAMES = [
     "majority_residue",
     "prime_marker",
     "prime_qval",
-    "meme_marker",
+    "meme_pval",
+    "meme_qval",
     "fel_selection",
     "fel_pval",
+    "fel_qval",
     "fel_alpha",
     "fel_beta",
 ]

--- a/drhip/config.py
+++ b/drhip/config.py
@@ -34,6 +34,7 @@ SITES_FIELDNAMES = [
     "substitutions",
     "majority_residue",
     "prime_marker",
+    "prime_qval",
     "meme_marker",
     "fel_selection",
 ]

--- a/drhip/methods/base.py
+++ b/drhip/methods/base.py
@@ -3,7 +3,7 @@ Base class and interfaces for HyPhy analysis methods.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class HyPhyMethod(ABC):
@@ -244,6 +244,40 @@ class HyPhyMethod(ABC):
                 continue
 
         return site_results
+
+    @staticmethod
+    def benjamini_hochberg_qvalues(
+        pvalues: List[Optional[float]],
+    ) -> List[Optional[float]]:
+        """Calculate Benjamini-Hochberg adjusted q-values.
+
+        Invalid or missing p-values should be passed as None. They are excluded
+        from the correction and returned as None in their original positions.
+        """
+        qvalues: List[Optional[float]] = [None] * len(pvalues)
+        valid_pvalues = [
+            (index, pvalue)
+            for index, pvalue in enumerate(pvalues)
+            if pvalue is not None and 0 <= pvalue <= 1
+        ]
+
+        if not valid_pvalues:
+            return qvalues
+
+        valid_pvalues.sort(key=lambda item: item[1])
+        number_of_tests = len(valid_pvalues)
+        previous_qvalue = 1.0
+
+        for rank, (original_index, pvalue) in enumerate(
+            reversed(valid_pvalues), start=1
+        ):
+            ascending_rank = number_of_tests - rank + 1
+            qvalue = min(previous_qvalue, pvalue * number_of_tests / ascending_rank)
+            adjusted_qvalue = min(qvalue, 1.0)
+            qvalues[original_index] = adjusted_qvalue
+            previous_qvalue = adjusted_qvalue
+
+        return qvalues
 
     def extract_common_fields(self, results: Dict[str, Any]) -> Dict[str, Any]:
         """Extract common fields from HyPhy results.

--- a/drhip/methods/cfel.py
+++ b/drhip/methods/cfel.py
@@ -315,11 +315,8 @@ class CfelMethod(HyPhyMethod):
                     if q_value_idx >= 0 and q_value_idx < len(row):
                         try:
                             q_value = float(row[q_value_idx])
-                            # Set the marker based on significance
-                            if q_value <= 0.20:
-                                q_value_str = f"{q_value:.3f}"  # Format p-value for significant sites
-                            else:
-                                q_value_str = "-"  # Use dash for non-significant sites
+                            # Always emit the p-value regardless of significance
+                            q_value_str = f"{q_value:.3f}"
                         except (ValueError, TypeError):
                             # Return NA for malformed data
                             q_value_str = "NA"

--- a/drhip/methods/fel.py
+++ b/drhip/methods/fel.py
@@ -161,7 +161,8 @@ class FelMethod(HyPhyMethod):
                 # Return site data - only include site-specific fields
                 return {
                     "fel_selection": selection_type if pvalue <= 0.05 else "neutral",
-                    "fel_pval": f"{pvalue:.3f}",
+                    #"fel_pval": f"{pvalue:.3f}",
+                    "fel_pval": f"{pvalue}",
                     "fel_alpha": f"{alpha:.3f}",
                     "fel_beta": f"{beta:.3f}",
                 }

--- a/drhip/methods/fel.py
+++ b/drhip/methods/fel.py
@@ -38,14 +38,14 @@ class FelMethod(HyPhyMethod):
         """Calculate negative selection statistics from MLE data.
 
         This helper calculates FEL negative selection statistics:
-        - negative_sites: Number of sites under negative selection (beta < alpha, p <= significance)
+        - negative_sites: Number of sites under negative selection (beta < alpha, q <= significance)
 
         Args:
             results: Raw results dictionary from JSON file
             alpha_col: Name of the column containing alpha (synonymous rate) values
             beta_col: Name of the column containing beta (non-synonymous rate) values
             pvalue_col: Name of the column containing p-values
-            significance: P-value threshold for significance (default: 0.05)
+            significance: Q-value threshold for significance (default: 0.05)
 
         Returns:
             Dictionary with negative selection statistics
@@ -68,16 +68,25 @@ class FelMethod(HyPhyMethod):
         if alpha_index < 0 or beta_index < 0 or pvalue_index < 0:
             return stats
 
+        rows = results["MLE"]["content"]["0"]
+        pvalues = []
+        for row in rows:
+            try:
+                pvalues.append(float(row[pvalue_index]))
+            except (ValueError, IndexError, TypeError):
+                pvalues.append(None)
+
+        qvalues = self.benjamini_hochberg_qvalues(pvalues)
+
         # Process each site
-        for row in results["MLE"]["content"]["0"]:
+        for row, qvalue in zip(rows, qvalues):
             try:
                 # Extract values
                 alpha = float(row[alpha_index])  # Alpha (synonymous rate)
                 beta = float(row[beta_index])  # Beta (non-synonymous rate)
-                p_value = float(row[pvalue_index])  # P-value
 
                 # Count sites based on selection criteria
-                if p_value <= significance and beta < alpha:
+                if qvalue is not None and qvalue <= significance and beta < alpha:
                     stats["negative_sites"] += 1
             except (ValueError, IndexError, TypeError):
                 # Skip this site if there's an error
@@ -120,6 +129,8 @@ class FelMethod(HyPhyMethod):
         Returns:
             Dictionary with site-specific metrics
         """
+        qvalues_by_site = self._site_qvalues(results, pvalue_col="p-value")
+
         # Define column names mapping
         column_names = {"alpha": "alpha", "beta": "beta", "p-value": "p-value"}
 
@@ -142,6 +153,7 @@ class FelMethod(HyPhyMethod):
                 return {
                     "fel_selection": "NA",
                     "fel_pval": "NA",
+                    "fel_qval": "NA",
                     "fel_alpha": "NA",
                     "fel_beta": "NA",
                 }
@@ -150,19 +162,24 @@ class FelMethod(HyPhyMethod):
                 alpha = float(row[alpha_index])
                 beta = float(row[beta_index])
                 pvalue = float(row[pvalue_index])
+                qvalue = qvalues_by_site.get(site_idx)
 
                 # Determine selection type
                 selection_type = (
                     "positive"
-                    if beta > alpha and pvalue <= 0.05
-                    else "negative" if beta < alpha and pvalue <= 0.05 else "neutral"
+                    if beta > alpha and qvalue is not None and qvalue <= 0.05
+                    else (
+                        "negative"
+                        if beta < alpha and qvalue is not None and qvalue <= 0.05
+                        else "neutral"
+                    )
                 )
 
                 # Return site data - only include site-specific fields
                 return {
-                    "fel_selection": selection_type if pvalue <= 0.05 else "neutral",
-                    #"fel_pval": f"{pvalue:.3f}",
+                    "fel_selection": selection_type,
                     "fel_pval": f"{pvalue}",
+                    "fel_qval": f"{qvalue}" if qvalue is not None else "NA",
                     "fel_alpha": f"{alpha:.3f}",
                     "fel_beta": f"{beta:.3f}",
                 }
@@ -171,12 +188,39 @@ class FelMethod(HyPhyMethod):
                 return {
                     "fel_selection": "NA",
                     "fel_pval": "NA",
+                    "fel_qval": "NA",
                     "fel_alpha": "NA",
                     "fel_beta": "NA",
                 }
 
         # Use the helper to process site data
         return self.process_site_mle_data(results, column_names, process_row)
+
+    def _site_qvalues(
+        self, results: Dict[str, Any], pvalue_col: str = "p-value"
+    ) -> Dict[int, float]:
+        """Calculate per-site FEL q-values for a single gene result."""
+        if not self.has_mle_content(results) or not self.has_mle_headers(results):
+            return {}
+
+        header_indices = self.get_header_indices(results)
+        pvalue_index = self.get_column_index(header_indices, pvalue_col, -1)
+        if pvalue_index < 0:
+            return {}
+
+        pvalues = []
+        for row in results["MLE"]["content"]["0"]:
+            try:
+                pvalues.append(float(row[pvalue_index]))
+            except (ValueError, IndexError, TypeError):
+                pvalues.append(None)
+
+        qvalues = self.benjamini_hochberg_qvalues(pvalues)
+        return {
+            site_idx: qvalue
+            for site_idx, qvalue in enumerate(qvalues, 1)
+            if qvalue is not None
+        }
 
     @staticmethod
     def get_summary_fields() -> List[str]:
@@ -186,7 +230,7 @@ class FelMethod(HyPhyMethod):
     @staticmethod
     def get_site_fields() -> List[str]:
         """Get list of site-specific fields produced by this method."""
-        return ["fel_selection", "fel_pval", "fel_alpha", "fel_beta"]
+        return ["fel_selection", "fel_pval", "fel_qval", "fel_alpha", "fel_beta"]
 
     @staticmethod
     def get_comparison_group_fields() -> List[str]:

--- a/drhip/methods/fel.py
+++ b/drhip/methods/fel.py
@@ -139,7 +139,12 @@ class FelMethod(HyPhyMethod):
                 or pvalue_index >= len(row)
             ):
                 # Return NA values for missing data
-                return {"fel_selection": "NA", "fel_pval": "NA"}
+                return {
+                    "fel_selection": "NA",
+                    "fel_pval": "NA",
+                    "fel_alpha": "NA",
+                    "fel_beta": "NA",
+                }
 
             try:
                 alpha = float(row[alpha_index])
@@ -157,10 +162,17 @@ class FelMethod(HyPhyMethod):
                 return {
                     "fel_selection": selection_type if pvalue <= 0.05 else "neutral",
                     "fel_pval": f"{pvalue:.3f}",
+                    "fel_alpha": f"{alpha:.3f}",
+                    "fel_beta": f"{beta:.3f}",
                 }
             except (ValueError, TypeError):
                 # Return NA values for malformed data
-                return {"fel_selection": "NA", "fel_pval": "NA"}
+                return {
+                    "fel_selection": "NA",
+                    "fel_pval": "NA",
+                    "fel_alpha": "NA",
+                    "fel_beta": "NA",
+                }
 
         # Use the helper to process site data
         return self.process_site_mle_data(results, column_names, process_row)
@@ -173,7 +185,7 @@ class FelMethod(HyPhyMethod):
     @staticmethod
     def get_site_fields() -> List[str]:
         """Get list of site-specific fields produced by this method."""
-        return ["fel_selection", "fel_pval"]
+        return ["fel_selection", "fel_pval", "fel_alpha", "fel_beta"]
 
     @staticmethod
     def get_comparison_group_fields() -> List[str]:

--- a/drhip/methods/fel.py
+++ b/drhip/methods/fel.py
@@ -139,7 +139,7 @@ class FelMethod(HyPhyMethod):
                 or pvalue_index >= len(row)
             ):
                 # Return NA values for missing data
-                return {"fel_selection": "NA"}
+                return {"fel_selection": "NA", "fel_pval": "NA"}
 
             try:
                 alpha = float(row[alpha_index])
@@ -155,11 +155,12 @@ class FelMethod(HyPhyMethod):
 
                 # Return site data - only include site-specific fields
                 return {
-                    "fel_selection": selection_type if pvalue <= 0.05 else "neutral"
+                    "fel_selection": selection_type if pvalue <= 0.05 else "neutral",
+                    "fel_pval": f"{pvalue:.3f}",
                 }
             except (ValueError, TypeError):
                 # Return NA values for malformed data
-                return {"fel_selection": "NA"}
+                return {"fel_selection": "NA", "fel_pval": "NA"}
 
         # Use the helper to process site data
         return self.process_site_mle_data(results, column_names, process_row)
@@ -172,7 +173,7 @@ class FelMethod(HyPhyMethod):
     @staticmethod
     def get_site_fields() -> List[str]:
         """Get list of site-specific fields produced by this method."""
-        return ["fel_selection"]
+        return ["fel_selection", "fel_pval"]
 
     @staticmethod
     def get_comparison_group_fields() -> List[str]:

--- a/drhip/methods/meme.py
+++ b/drhip/methods/meme.py
@@ -46,14 +46,17 @@ class MemeMethod(HyPhyMethod):
                 header_indices, "p-value", 7
             )  # P-value for episodic selection
 
+            pvalues = []
             for row in results["MLE"]["content"]["0"]:
                 try:
-                    p_value = float(row[pvalue_index])
-                    if p_value <= 0.05:
-                        positive_sites += 1
+                    pvalues.append(float(row[pvalue_index]))
                 except (ValueError, TypeError, IndexError):
-                    # Skip rows with invalid data
-                    pass
+                    pvalues.append(None)
+
+            qvalues = self.benjamini_hochberg_qvalues(pvalues)
+            positive_sites = sum(
+                1 for qvalue in qvalues if qvalue is not None and qvalue <= 0.05
+            )
 
         # Store the count of sites under episodic selection in the summary
         processed["positive_sites"] = positive_sites
@@ -69,6 +72,8 @@ class MemeMethod(HyPhyMethod):
         Returns:
             Dictionary with site-specific metrics
         """
+        qvalues_by_site = self._site_qvalues(results, pvalue_col="p-value")
+
         # Define column names mapping
         column_names = {"site": "Site", "p-value": "p-value"}
 
@@ -78,19 +83,47 @@ class MemeMethod(HyPhyMethod):
 
             # Check if we have valid indices and data
             if pvalue_index < 0 or pvalue_index >= len(row):
-                return {"meme_marker": "NA"}  # Use NA for missing data
+                return {"meme_pval": "NA", "meme_qval": "NA"}
 
             try:
                 pvalue = float(row[pvalue_index])
-                # Always emit the p-value regardless of significance
-                # return {"meme_marker": f"{pvalue:.3f}"}
-                return {"meme_marker": f"{pvalue}"}
+                qvalue = qvalues_by_site.get(site_idx)
+                return {
+                    "meme_pval": f"{pvalue}",
+                    "meme_qval": f"{qvalue}" if qvalue is not None else "NA",
+                }
             except (ValueError, TypeError):
                 # Return NA for malformed data
-                return {"meme_marker": "NA"}
+                return {"meme_pval": "NA", "meme_qval": "NA"}
 
         # Use the helper to process site data
         return self.process_site_mle_data(results, column_names, process_row)
+
+    def _site_qvalues(
+        self, results: Dict[str, Any], pvalue_col: str = "p-value"
+    ) -> Dict[int, float]:
+        """Calculate per-site MEME q-values for a single gene result."""
+        if not self.has_mle_content(results) or not self.has_mle_headers(results):
+            return {}
+
+        header_indices = self.get_header_indices(results)
+        pvalue_index = self.get_column_index(header_indices, pvalue_col, -1)
+        if pvalue_index < 0:
+            return {}
+
+        pvalues = []
+        for row in results["MLE"]["content"]["0"]:
+            try:
+                pvalues.append(float(row[pvalue_index]))
+            except (ValueError, IndexError, TypeError):
+                pvalues.append(None)
+
+        qvalues = self.benjamini_hochberg_qvalues(pvalues)
+        return {
+            site_idx: qvalue
+            for site_idx, qvalue in enumerate(qvalues, 1)
+            if qvalue is not None
+        }
 
     @staticmethod
     def get_summary_fields() -> List[str]:
@@ -100,7 +133,7 @@ class MemeMethod(HyPhyMethod):
     @staticmethod
     def get_site_fields() -> List[str]:
         """Get list of site-specific fields produced by this method."""
-        return ["meme_marker"]
+        return ["meme_pval", "meme_qval"]
 
     @staticmethod
     def get_comparison_group_fields() -> List[str]:

--- a/drhip/methods/meme.py
+++ b/drhip/methods/meme.py
@@ -83,7 +83,8 @@ class MemeMethod(HyPhyMethod):
             try:
                 pvalue = float(row[pvalue_index])
                 # Always emit the p-value regardless of significance
-                return {"meme_marker": f"{pvalue:.3f}"}
+                # return {"meme_marker": f"{pvalue:.3f}"}
+                return {"meme_marker": f"{pvalue}"}
             except (ValueError, TypeError):
                 # Return NA for malformed data
                 return {"meme_marker": "NA"}

--- a/drhip/methods/meme.py
+++ b/drhip/methods/meme.py
@@ -82,14 +82,8 @@ class MemeMethod(HyPhyMethod):
 
             try:
                 pvalue = float(row[pvalue_index])
-
-                # Set the marker based on significance
-                if pvalue <= 0.05:
-                    marker = f"{pvalue:.3f}"  # Format p-value for significant sites
-                else:
-                    marker = "-"  # Use dash for non-significant sites
-
-                return {"meme_marker": marker}
+                # Always emit the p-value regardless of significance
+                return {"meme_marker": f"{pvalue:.3f}"}
             except (ValueError, TypeError):
                 # Return NA for malformed data
                 return {"meme_marker": "NA"}

--- a/drhip/methods/prime.py
+++ b/drhip/methods/prime.py
@@ -138,7 +138,7 @@ class PrimeMethod(HyPhyMethod):
             # Determine the marker value
             if not has_valid_data or not pvals or not prime_tags:
                 # For missing or malformed data
-                return {"prime_marker": "NA", "prime_pval": "NA"}
+                return {"prime_marker": "NA", "prime_qval": "NA"}
             elif omnibus_qval <= 0.05:
                 # For sites with significant properties
                 significant_tags = [

--- a/drhip/methods/prime.py
+++ b/drhip/methods/prime.py
@@ -82,12 +82,15 @@ class PrimeMethod(HyPhyMethod):
         # First, extract property tags and p-value indices
         prime_tags = []
         p_indices = []
+        overall_q_index = None
 
         if self.has_mle_headers(results):
             headers = results["MLE"]["headers"]
 
             for i, (short_label, description) in enumerate(headers):
-                if short_label == "p-value":
+                if short_label == "q-value":
+                    overall_q_index = i
+                elif short_label == "p-value":
                     p_indices.append(i)
                     prime_tags.append((0, "overall"))
                 elif short_label.startswith("p") and short_label[1:].isdigit():
@@ -110,6 +113,7 @@ class PrimeMethod(HyPhyMethod):
         def process_row(site_idx, row, column_indices):
             # Get p-values for all properties, with error handling
             pvals = []
+            omnibus_qval = None
             has_valid_data = True
 
             for idx in p_indices:
@@ -123,19 +127,30 @@ class PrimeMethod(HyPhyMethod):
                     has_valid_data = False  # Mark as invalid if conversion fails
                     break
 
+            try:
+                if overall_q_index and overall_q_index < len(row):
+                    omnibus_qval = float(row[overall_q_index])
+                else:
+                    has_valid_data = False  # Mark as invalid if index out of range
+            except (ValueError, TypeError):
+                has_valid_data = False  # Mark as invalid if conversion fails
+
             # Determine the marker value
             if not has_valid_data or not pvals or not prime_tags:
                 # For missing or malformed data
-                return {"prime_marker": "NA"}
-            elif min(pvals) <= 0.05:
+                return {"prime_marker": "NA", "prime_pval": "NA"}
+            elif omnibus_qval <= 0.05:
                 # For sites with significant properties
                 significant_tags = [
                     prime_tags[i] for i, pval in enumerate(pvals) if pval <= 0.05
                 ]
-                return {"prime_marker": ",".join(significant_tags)}
+                return {
+                    "prime_marker": ",".join(significant_tags),
+                    "prime_qval": omnibus_qval,
+                }
             else:
                 # For non-significant sites, use dash as in original End2End pipeline
-                return {"prime_marker": "-"}
+                return {"prime_marker": "-", "prime_qval": omnibus_qval}
 
         # Use the helper to process site data
         return self.process_site_mle_data(results, column_names, process_row)
@@ -148,7 +163,7 @@ class PrimeMethod(HyPhyMethod):
     @staticmethod
     def get_site_fields() -> List[str]:
         """Get list of site-specific fields produced by this method."""
-        return ["prime_marker"]
+        return ["prime_marker", "prime_qval"]
 
     @staticmethod
     def get_comparison_group_fields() -> List[str]:

--- a/drhip/version.py
+++ b/drhip/version.py
@@ -1,3 +1,3 @@
 """Version information."""
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/tests/test_cfel_Beta_and_Qvalue_updates.py
+++ b/tests/test_cfel_Beta_and_Qvalue_updates.py
@@ -81,7 +81,7 @@ def test_cfel_diff_sites_count_from_qvalue(comparison_results_dir: str):
 def test_cfel_marker_and_beta_formatting(comparison_results_dir: str):
     """
     CfelMethod.process_comparison_site_data should:
-    - set cfel_marker to formatted Q-value ("{q:.3f}") when q <= 0.20, else '-'
+    - set cfel_marker to formatted Q-value ("{q:.3f}") when available
     - set cfel_beta to per-group formatted value:
         * '0.000' for exact 0
         * scientific notation with 3 decimals if |beta|<1e-3 or >= 1e3
@@ -133,7 +133,7 @@ def test_cfel_marker_and_beta_formatting(comparison_results_dir: str):
             if q_idx < len(row):
                 try:
                     q = float(row[q_idx])
-                    expected_marker = f"{q:.3f}" if q <= 0.20 else "-"
+                    expected_marker = f"{q:.3f}"
                 except (ValueError, TypeError):
                     expected_marker = "NA"
 
@@ -150,9 +150,9 @@ def test_cfel_marker_and_beta_formatting(comparison_results_dir: str):
                 # cfel_marker formatting
                 assert "cfel_marker" in gdata
                 marker = gdata["cfel_marker"]
-                # Either '-', or a numeric string with exactly 3 decimals
+                # Either NA, or a numeric string with exactly 3 decimals
                 assert marker == expected_marker or marker == "NA"
-                if marker not in ("-", "NA"):
+                if marker != "NA":
                     assert re.fullmatch(r"\d*\.\d{3}", marker) is not None
 
                 # cfel_beta formatting

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -92,6 +92,8 @@ def test_fel_uses_bh_qvalues_for_selection():
     assert summary["negative_sites"] == 1
     assert site_data[1]["fel_selection"] == "negative"
     assert site_data[2]["fel_selection"] == "neutral"
+    assert float(site_data[1]["fel_pval"]) == 0.01
+    assert float(site_data[2]["fel_pval"]) == 0.04
     assert float(site_data[1]["fel_qval"]) == 0.04
     assert round(float(site_data[2]["fel_qval"]), 3) == 0.068
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -66,6 +66,36 @@ def test_fel_method_processing(real_fel_results):
         assert len(site_info) > 0
 
 
+def test_fel_uses_bh_qvalues_for_selection():
+    method = FelMethod()
+    results = {
+        "MLE": {
+            "headers": [
+                ["alpha", "Synonymous rate"],
+                ["beta", "Non-synonymous rate"],
+                ["p-value", "P-value"],
+            ],
+            "content": {
+                "0": [
+                    [2.0, 1.0, 0.01],
+                    [2.0, 1.0, 0.04],
+                    [1.0, 2.0, 0.051],
+                    [2.0, 1.0, 0.2],
+                ]
+            },
+        }
+    }
+
+    summary = method.process_results(results)
+    site_data = method.process_site_data(results)
+
+    assert summary["negative_sites"] == 1
+    assert site_data[1]["fel_selection"] == "negative"
+    assert site_data[2]["fel_selection"] == "neutral"
+    assert float(site_data[1]["fel_qval"]) == 0.04
+    assert round(float(site_data[2]["fel_qval"]), 3) == 0.068
+
+
 def test_meme_method_processing(real_meme_results):
     """Test MEME method result processing."""
     method = MemeMethod()
@@ -88,6 +118,25 @@ def test_meme_method_processing(real_meme_results):
         # Just verify that we have some data for the site
         assert isinstance(site_info, dict)
         assert len(site_info) > 0
+
+
+def test_meme_uses_bh_qvalues_for_positive_sites():
+    method = MemeMethod()
+    results = {
+        "MLE": {
+            "headers": [["p-value", "P-value"]],
+            "content": {"0": [[0.01], [0.04], [0.051], [0.2]]},
+        }
+    }
+
+    summary = method.process_results(results)
+    site_data = method.process_site_data(results)
+
+    assert summary["positive_sites"] == 1
+    assert float(site_data[1]["meme_pval"]) == 0.01
+    assert float(site_data[2]["meme_pval"]) == 0.04
+    assert float(site_data[1]["meme_qval"]) == 0.04
+    assert round(float(site_data[2]["meme_qval"]), 3) == 0.068
 
 
 def test_method_field_generation():

--- a/tests/test_process_gene.py
+++ b/tests/test_process_gene.py
@@ -3,6 +3,7 @@ Tests for process_gene module.
 """
 
 import csv
+import json
 import os
 import shutil
 import tempfile
@@ -87,6 +88,74 @@ def test_process_gene_sites_content(results_dir):
                 if any(method in key.lower() for method in ["fel", "meme", "busted"])
             ]
             assert len(method_fields) > 0
+
+
+def test_process_gene_sites_report_all_fel_and_meme_pvalues():
+    """Generated site CSVs should keep raw FEL/MEME p-values, even if not significant."""
+    gene_name = "synthetic_gene"
+    rows = [[0.01], [0.04], [0.051], [0.2]]
+
+    fel_results = {
+        "tested": {"0": {"branch1": "test", "branch2": "test"}},
+        "branch attributes": {
+            "0": {
+                "branch1": {"length": 0.1},
+                "branch2": {"length": 0.2},
+            }
+        },
+        "MLE": {
+            "headers": [
+                ["alpha", "Synonymous rate"],
+                ["beta", "Non-synonymous rate"],
+                ["p-value", "P-value"],
+            ],
+            "content": {
+                "0": [
+                    [2.0, 1.0, 0.01],
+                    [2.0, 1.0, 0.04],
+                    [1.0, 2.0, 0.051],
+                    [2.0, 1.0, 0.2],
+                ]
+            },
+        },
+    }
+    meme_results = {
+        "MLE": {
+            "headers": [["p-value", "P-value"]],
+            "content": {"0": rows},
+        }
+    }
+
+    with tempfile.TemporaryDirectory() as results_dir:
+        with tempfile.TemporaryDirectory() as output_dir:
+            os.makedirs(os.path.join(results_dir, "FEL"))
+            os.makedirs(os.path.join(results_dir, "MEME"))
+
+            with open(os.path.join(results_dir, "FEL", f"{gene_name}.FEL.json"), "w") as f:
+                json.dump(fel_results, f)
+            with open(
+                os.path.join(results_dir, "MEME", f"{gene_name}.MEME.json"), "w"
+            ) as f:
+                json.dump(meme_results, f)
+
+            process_gene(gene_name, results_dir, output_dir)
+
+            sites_file = os.path.join(output_dir, f"{gene_name}_sites.csv")
+            with open(sites_file) as f:
+                site_rows = list(csv.DictReader(f))
+
+    assert len(site_rows) == 4
+    for field in ["fel_pval", "fel_qval", "meme_pval", "meme_qval"]:
+        assert field in site_rows[0]
+        assert all(row[field] != "-" for row in site_rows)
+
+    second_site = site_rows[1]
+    assert second_site["site"] == "2"
+    assert float(second_site["fel_pval"]) == 0.04
+    assert float(second_site["meme_pval"]) == 0.04
+    assert round(float(second_site["fel_qval"]), 3) == 0.068
+    assert round(float(second_site["meme_qval"]), 3) == 0.068
+    assert second_site["fel_selection"] == "neutral"
 
 
 def test_process_gene_comparison_data(comparison_results_dir):


### PR DESCRIPTION
Addresses issue #18 by reporting MEME and FEL p- and q-values for all sites, rather than just significant sites. The changes allow for easier machine-parsing of results files, and lets users set their own significance thresholds